### PR TITLE
Improve bulk file performance and packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       run: dotnet build src/AggregateConfigBuildTask.sln --configuration Release -warnaserror -p:Version=${{ steps.get_version.outputs.VERSION }}
 
     - name: Run tests for AggregateConfigBuildTask solution
-      run: dotnet test src/AggregateConfigBuildTask.sln --configuration Release -warnaserror -p:Version=${{ steps.get_version.outputs.VERSION }}
+      run: dotnet test src/AggregateConfigBuildTask.sln --configuration Release -warnaserror -p:Version=${{ steps.get_version.outputs.VERSION }} -p:CollectCoverage=true
 
     - name: Upload NuGetPackage artifact
       uses: actions/upload-artifact@v4
@@ -91,7 +91,7 @@ jobs:
       run: dotnet build test/IntegrationTests.sln --configuration Release -warnaserror -p:Version=${{ needs.build.outputs.VERSION }}
 
     - name: Run IntegrationTests
-      run: dotnet test test/IntegrationTests.sln --configuration Release -warnaserror -p:Version=${{ needs.build.outputs.VERSION }}
+      run: dotnet test test/IntegrationTests.sln --configuration Release -warnaserror -p:Version=${{ needs.build.outputs.VERSION }} -p:CollectCoverage=true
 
     - name: Upload integration results artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,9 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: NuGetPackage
-        path: src/Task/bin/Release/AggregateConfigBuildTask.${{ steps.get_version.outputs.VERSION }}.nupkg
+        path: |
+          src/Task/bin/Release/AggregateConfigBuildTask.${{ steps.get_version.outputs.VERSION }}.nupkg
+          src/Task/bin/Release/AggregateConfigBuildTask.${{ steps.get_version.outputs.VERSION }}.snupkg
 
   integration_tests:
     needs: build

--- a/README.md
+++ b/README.md
@@ -25,10 +25,7 @@ dotnet add package AggregateConfigBuildTask
 Alternatively, add the following line to your `.csproj` file:
 
 ```xml
-<PackageReference Include="AggregateConfigBuildTask" Version="{latest}">
-  <PrivateAssets>all</PrivateAssets>
-  <ExcludeAssets>native;contentFiles;analyzers;runtime</ExcludeAssets>
-</PackageReference>
+<PackageReference Include="AggregateConfigBuildTask" Version="{latest}" />
 ```
 
 `{latest}` can be found [here](https://www.nuget.org/packages/AggregateConfigBuildTask#versions-body-tab).

--- a/src/AggregateConfigBuildTask.sln
+++ b/src/AggregateConfigBuildTask.sln
@@ -12,6 +12,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{29D0AE56-C184-4741-824F-521198552928}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Global

--- a/src/Contracts/Contracts.csproj
+++ b/src/Contracts/Contracts.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
 </Project>

--- a/src/Contracts/InputOutputEnums.cs
+++ b/src/Contracts/InputOutputEnums.cs
@@ -1,4 +1,4 @@
-﻿namespace AggregateConfig.Contracts
+﻿namespace AggregateConfigBuildTask.Contracts
 {
     public enum OutputTypeEnum
     {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,30 @@
+<Project>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<!-- Build packages-->
+	<ItemGroup>
+		<PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" PrivateAssets="all" />
+		<PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" />
+		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+	</ItemGroup>
+	<!-- Runtime packages -->
+	<ItemGroup>
+		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PrivateAssets="all" />
+		<PackageVersion Include="System.Text.Json" Version="8.0.4" PrivateAssets="all" />
+		<PackageVersion Include="YamlDotNet" Version="16.1.0" PrivateAssets="all" GeneratePathProperty="true" />
+		<PackageVersion Include="YamlDotNet.System.Text.Json" Version="1.5.0" PrivateAssets="all" />
+	</ItemGroup>
+	<!-- Test packages -->
+	<ItemGroup>
+		<PackageVersion Include="coverlet.collector" Version="6.0.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageVersion Include="Moq" Version="4.20.72" />
+		<PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
+		<PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
+	</ItemGroup>
+	<!-- Global packages -->
+	<ItemGroup>
+		<GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.6" />
+	</ItemGroup>
+</Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,30 +1,30 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-	</PropertyGroup>
-	<!-- Build packages-->
-	<ItemGroup>
-		<PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" PrivateAssets="all" />
-		<PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" />
-		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-	</ItemGroup>
-	<!-- Runtime packages -->
-	<ItemGroup>
-		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PrivateAssets="all" />
-		<PackageVersion Include="System.Text.Json" Version="8.0.4" PrivateAssets="all" />
-		<PackageVersion Include="YamlDotNet" Version="16.1.0" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageVersion Include="YamlDotNet.System.Text.Json" Version="1.5.0" PrivateAssets="all" />
-	</ItemGroup>
-	<!-- Test packages -->
-	<ItemGroup>
-		<PackageVersion Include="coverlet.collector" Version="6.0.0" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageVersion Include="Moq" Version="4.20.72" />
-		<PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
-		<PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
-	</ItemGroup>
-	<!-- Global packages -->
-	<ItemGroup>
-		<GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.6" />
-	</ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <!-- Build packages-->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+  </ItemGroup>
+  <!-- Runtime packages -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PrivateAssets="all" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" PrivateAssets="all" />
+    <PackageVersion Include="YamlDotNet" Version="16.1.0" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageVersion Include="YamlDotNet.System.Text.Json" Version="1.5.0" PrivateAssets="all" />
+  </ItemGroup>
+  <!-- Test packages -->
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+  <!-- Global packages -->
+  <ItemGroup>
+    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.6" />
+  </ItemGroup>
 </Project>

--- a/src/Task/AggregateConfigBuildTask.csproj
+++ b/src/Task/AggregateConfigBuildTask.csproj
@@ -4,6 +4,15 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <Deterministic>true</Deterministic>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <SourceLinkCreate>true</SourceLinkCreate>
+        <NoWarn>NU5100</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -20,6 +29,10 @@
         <PackageReleaseNotes>https://github.com/richardsondev/AggregateConfigBuildTask/releases/tag/v$(Version)</PackageReleaseNotes>
         <PackageReadmeFile>docs/README.md</PackageReadmeFile>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+        <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
     </PropertyGroup>
 
     <ItemGroup>
@@ -30,6 +43,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
         <PackageReference Include="ReferenceTrimmer" Version="3.3.6" PrivateAssets="all" />
     </ItemGroup>
 
@@ -42,14 +56,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="$(OutputPath)/Contracts.dll" Pack="true" PackagePath="/lib/netstandard2.0/" />
-        <None Include="$(OutputPath)/Microsoft.Bcl.AsyncInterfaces.dll" Pack="true" PackagePath="/lib/netstandard2.0/" />
-        <None Include="$(OutputPath)/System.Text.Json.dll" Pack="true" PackagePath="/lib/netstandard2.0/" />
-        <None Include="$(OutputPath)/YamlDotNet.dll" Pack="true" PackagePath="/lib/netstandard2.0/" />
+        <None Include="$(OutputPath)/Contracts.dll" Pack="true" PackagePath="/tasks/netstandard2.0/" />
+        <None Include="$(OutputPath)/Microsoft.Bcl.AsyncInterfaces.dll" Pack="true" PackagePath="/tasks/netstandard2.0/" />
+        <None Include="$(OutputPath)/System.Text.Json.dll" Pack="true" PackagePath="/tasks/netstandard2.0/" />
+        <None Include="$(OutputPath)/YamlDotNet.dll" Pack="true" PackagePath="/tasks/netstandard2.0/" />
         <None Include="$(PkgYamlDotNet)/LICENSE.txt" Pack="true" PackagePath="/licenses/YamlDotNet">
             <Link>licenses/YamlDotNet/LICENSE.txt</Link>
         </None>
-        <None Include="$(OutputPath)/YamlDotNet.System.Text.Json.dll" Pack="true" PackagePath="/lib/netstandard2.0/" />
+        <None Include="$(OutputPath)/YamlDotNet.System.Text.Json.dll" Pack="true" PackagePath="/tasks/netstandard2.0/" />
         <None Include="build/AggregateConfigBuildTask.targets" Pack="true" PackagePath="/build/AggregateConfigBuildTask.targets" />
         <None Include="../../LICENSE" Pack="true" PackagePath="/licenses/">
             <Link>licenses/LICENSE</Link>

--- a/src/Task/AggregateConfigBuildTask.csproj
+++ b/src/Task/AggregateConfigBuildTask.csproj
@@ -41,18 +41,17 @@
 
     <!-- Build time packages-->
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-        <PackageReference Include="ReferenceTrimmer" Version="3.3.6" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     </ItemGroup>
 
     <!-- Runtime packages -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PrivateAssets="all" />
-        <PackageReference Include="System.Text.Json" Version="8.0.4" PrivateAssets="all" />
-        <PackageReference Include="YamlDotNet" Version="16.1.0" PrivateAssets="all" GeneratePathProperty="true" />
-        <PackageReference Include="YamlDotNet.System.Text.Json" Version="1.5.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" PrivateAssets="all" />
+        <PackageReference Include="System.Text.Json" PrivateAssets="all" />
+        <PackageReference Include="YamlDotNet" PrivateAssets="all" GeneratePathProperty="true" />
+        <PackageReference Include="YamlDotNet.System.Text.Json" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Task/FileHandlers/ArmParametersFileHandler.cs
+++ b/src/Task/FileHandlers/ArmParametersFileHandler.cs
@@ -2,12 +2,13 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 
-namespace AggregateConfig.FileHandlers
+namespace AggregateConfigBuildTask.FileHandlers
 {
     public class ArmParametersFileHandler : IOutputWriter, IInputReader
     {
-        IFileSystem fileSystem;
+        readonly IFileSystem fileSystem;
 
         internal ArmParametersFileHandler(IFileSystem fileSystem)
         {
@@ -15,7 +16,7 @@ namespace AggregateConfig.FileHandlers
         }
 
         /// <inheritdoc/>
-        public JsonElement ReadInput(string inputPath)
+        public ValueTask<JsonElement> ReadInput(string inputPath)
         {
             using (var stream = fileSystem.OpenRead(inputPath))
             {
@@ -40,10 +41,10 @@ namespace AggregateConfig.FileHandlers
                         }
 
                         var modifiedJson = modifiedParameters.ToJsonString();
-                        return JsonSerializer.Deserialize<JsonElement>(modifiedJson);
+                        return new ValueTask<JsonElement>(Task.FromResult(JsonSerializer.Deserialize<JsonElement>(modifiedJson)));
                     }
 
-                    return jsonDoc.RootElement.Clone();
+                    return new ValueTask<JsonElement>(Task.FromResult(jsonDoc.RootElement.Clone()));
                 }
             }
         }

--- a/src/Task/FileHandlers/FileHandlerFactory.cs
+++ b/src/Task/FileHandlers/FileHandlerFactory.cs
@@ -1,8 +1,8 @@
-﻿using AggregateConfig.Contracts;
+﻿using AggregateConfigBuildTask.Contracts;
 using System;
 using System.Collections.Generic;
 
-namespace AggregateConfig.FileHandlers
+namespace AggregateConfigBuildTask.FileHandlers
 {
     public static class FileHandlerFactory
     {

--- a/src/Task/FileHandlers/IInputReader.cs
+++ b/src/Task/FileHandlers/IInputReader.cs
@@ -1,9 +1,10 @@
 ﻿using System.Text.Json;
+using System.Threading.Tasks;
 
-namespace AggregateConfig.FileHandlers
+namespace AggregateConfigBuildTask.FileHandlers
 {
     public interface IInputReader
     {
-        JsonElement ReadInput(string inputPath);
+        ValueTask<JsonElement> ReadInput(string inputPath);
     }
 }

--- a/src/Task/FileHandlers/IOutputWriter.cs
+++ b/src/Task/FileHandlers/IOutputWriter.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
 
-namespace AggregateConfig.FileHandlers
+namespace AggregateConfigBuildTask.FileHandlers
 {
     public interface IOutputWriter
     {

--- a/src/Task/FileHandlers/JsonFileHandler.cs
+++ b/src/Task/FileHandlers/JsonFileHandler.cs
@@ -1,10 +1,11 @@
 ﻿using System.Text.Json;
+using System.Threading.Tasks;
 
-namespace AggregateConfig.FileHandlers
+namespace AggregateConfigBuildTask.FileHandlers
 {
     public class JsonFileHandler : IOutputWriter, IInputReader
     {
-        IFileSystem fileSystem;
+        readonly IFileSystem fileSystem;
 
         internal JsonFileHandler(IFileSystem fileSystem)
         {
@@ -12,11 +13,11 @@ namespace AggregateConfig.FileHandlers
         }
 
         /// <inheritdoc/>
-        public JsonElement ReadInput(string inputPath)
+        public ValueTask<JsonElement> ReadInput(string inputPath)
         {
             using (var json = fileSystem.OpenRead(inputPath))
             {
-                return JsonSerializer.Deserialize<JsonElement>(json);
+                return JsonSerializer.DeserializeAsync<JsonElement>(json);
             }
         }
 

--- a/src/Task/FileHandlers/YamlFileHandler.cs
+++ b/src/Task/FileHandlers/YamlFileHandler.cs
@@ -1,14 +1,15 @@
 ﻿using System.IO;
 using System.Text.Json;
+using System.Threading.Tasks;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.System.Text.Json;
 
-namespace AggregateConfig.FileHandlers
+namespace AggregateConfigBuildTask.FileHandlers
 {
     public class YamlFileHandler : IOutputWriter, IInputReader
     {
-        IFileSystem fileSystem;
+        readonly IFileSystem fileSystem;
 
         internal YamlFileHandler(IFileSystem fileSystem)
         {
@@ -16,16 +17,18 @@ namespace AggregateConfig.FileHandlers
         }
 
         /// <inheritdoc/>
-        public JsonElement ReadInput(string inputPath)
+        public ValueTask<JsonElement> ReadInput(string inputPath)
         {
             using (TextReader reader = fileSystem.OpenText(inputPath))
             {
-                return new DeserializerBuilder()
-                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                    .WithTypeConverter(new SystemTextJsonYamlTypeConverter())
-                    .WithTypeInspector(x => new SystemTextJsonTypeInspector(x))
-                    .Build()
-                    .Deserialize<JsonElement>(reader);
+                return new ValueTask<JsonElement>(
+                    Task.FromResult(
+                        new DeserializerBuilder()
+                            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                            .WithTypeConverter(new SystemTextJsonYamlTypeConverter())
+                            .WithTypeInspector(x => new SystemTextJsonTypeInspector(x))
+                            .Build()
+                            .Deserialize<JsonElement>(reader)));
             }
         }
 

--- a/src/Task/FileSystem/FileSystem.cs
+++ b/src/Task/FileSystem/FileSystem.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace AggregateConfig
+namespace AggregateConfigBuildTask
 {
     internal class FileSystem : IFileSystem
     {

--- a/src/Task/FileSystem/IFileSystem.cs
+++ b/src/Task/FileSystem/IFileSystem.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace AggregateConfig
+namespace AggregateConfigBuildTask
 {
     /// <summary>
     /// Interface for a file system abstraction, allowing various implementations to handle file operations.

--- a/src/Task/ObjectManager.cs
+++ b/src/Task/ObjectManager.cs
@@ -175,8 +175,9 @@ namespace AggregateConfigBuildTask
         /// </summary>
         /// <param name="finalResult">The object that is expected to be a JSON object (JsonElement) where additional properties will be injected.</param>
         /// <param name="additionalPropertiesDictionary">A dictionary of additional properties to inject.</param>
+        /// <param name="log">Logger reference.</param>
         /// <returns>True if the properties were successfully injected, false otherwise.</returns>
-        public static async Task<JsonElement?> InjectAdditionalProperties(JsonElement? finalResult, Dictionary<string, string> additionalPropertiesDictionary)
+        public static async Task<JsonElement?> InjectAdditionalProperties(JsonElement? finalResult, Dictionary<string, string> additionalPropertiesDictionary, TaskLoggingHelper log)
         {
             if (additionalPropertiesDictionary?.Count > 0)
             {
@@ -194,7 +195,7 @@ namespace AggregateConfigBuildTask
                 }
                 else
                 {
-                    Console.Error.WriteLine("Additional properties could not be injected since the top-level is not a JSON object.");
+                    log.LogWarning("Additional properties could not be injected since the top-level is not a JSON object.");
                     return finalResult;
                 }
             }

--- a/src/Task/Polyfills/ListExtensions.cs
+++ b/src/Task/Polyfills/ListExtensions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AggregateConfigBuildTask
+{
+    public static class ListExtensions
+    {
+        /// <summary>
+        /// Splits a list into chunks of the specified size.
+        /// </summary>
+        /// <param name="source">The list to split into chunks.</param>
+        /// <param name="chunkSize">The size of each chunk.</param>
+        /// <returns>An IEnumerable of string arrays, each containing a chunk of the original list.</returns>
+        public static IEnumerable<IEnumerable<string>> Chunk(this List<string> source, int chunkSize)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (chunkSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(chunkSize), "Chunk size must be greater than 0.");
+            }
+
+            for (int i = 0; i < source.Count; i += chunkSize)
+            {
+                yield return source.GetRange(i, Math.Min(chunkSize, source.Count - i));
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously processes each element of a collection in parallel, with a limit on the number of concurrent tasks.
+        /// </summary>
+        /// <typeparam name="TSource">The type of elements in the source collection.</typeparam>
+        /// <param name="source">The collection of elements to process.</param>
+        /// <param name="degreeOfParallelism">The maximum number of tasks to run concurrently.</param>
+        /// <param name="body">The asynchronous delegate to execute for each element in the source collection.</param>
+        /// <returns>A task that represents the asynchronous processing of the collection.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the source or body is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the degree of parallelism is less than 1.</exception>
+        public static async Task ForEachAsync<TSource>(
+            this IEnumerable<TSource> source,
+            int degreeOfParallelism,
+            Func<TSource, Task> body)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (body == null) throw new ArgumentNullException(nameof(body));
+            if (degreeOfParallelism < 1) throw new ArgumentOutOfRangeException(nameof(degreeOfParallelism), "Degree of parallelism must be at least 1.");
+
+            var semaphore = new SemaphoreSlim(degreeOfParallelism);
+
+            var tasks = source.Select(async item =>
+            {
+                await semaphore.WaitAsync();
+                try
+                {
+                    await body(item);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            });
+
+            await Task.WhenAll(tasks);
+        }
+    }
+}

--- a/src/Task/build/AggregateConfigBuildTask.targets
+++ b/src/Task/build/AggregateConfigBuildTask.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 
     <UsingTask TaskName="AggregateConfig"
-        AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\AggregateConfigBuildTask.dll" />
+        AssemblyFile="$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\AggregateConfigBuildTask.dll" />
 
 </Project>

--- a/src/UnitTests/TaskUnixTests.cs
+++ b/src/UnitTests/TaskUnixTests.cs
@@ -1,4 +1,4 @@
-namespace AggregateConfig.Tests.Unit
+namespace AggregateConfigBuildTask.Tests.Unit
 {
     [TestClass]
     public class TaskUnixTests : TaskTestBase

--- a/src/UnitTests/TaskWindowsTests.cs
+++ b/src/UnitTests/TaskWindowsTests.cs
@@ -1,4 +1,4 @@
-namespace AggregateConfig.Tests.Unit
+namespace AggregateConfigBuildTask.Tests.Unit
 {
     [TestClass]
     public class TaskWindowsTests : TaskTestBase

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -12,14 +12,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Moq" Version="4.20.71" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-        <PackageReference Include="ReferenceTrimmer" Version="3.3.6" PrivateAssets="all" />
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="Microsoft.Build.Framework" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="MSTest.TestAdapter" />
+        <PackageReference Include="MSTest.TestFramework" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -8,6 +8,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/UnitTests/VirtualFileSystem.cs
+++ b/src/UnitTests/VirtualFileSystem.cs
@@ -6,22 +6,16 @@ using System.Text.RegularExpressions;
 
 namespace AggregateConfigBuildTask.Tests.Unit
 {
-    internal class VirtualFileSystem : IFileSystem
+    internal class VirtualFileSystem(bool isWindowsMode = true) : IFileSystem
     {
-        private readonly bool isWindowsMode = false;
-        private readonly Dictionary<string, string> fileSystem;
+        private readonly bool isWindowsMode = isWindowsMode;
+        private readonly Dictionary<string, string> fileSystem = new(
+                isWindowsMode ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal
+            );
 
         private RegexOptions RegexOptions => isWindowsMode ? RegexOptions.IgnoreCase : RegexOptions.None;
         private StringComparison StringComparison => isWindowsMode ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         private string EnvironmentLineBreak => isWindowsMode ? "\r\n" : "\n";
-
-        public VirtualFileSystem(bool isWindowsMode = true)
-        {
-            this.isWindowsMode = isWindowsMode;
-            this.fileSystem = new Dictionary<string, string>(
-                isWindowsMode ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal
-            );
-        }
 
         /// <inheritdoc/>
         public string[] GetFiles(string path, string searchPattern)
@@ -44,7 +38,7 @@ namespace AggregateConfigBuildTask.Tests.Unit
                 }
             }
 
-            return files.ToArray();
+            return [.. files];
         }
 
         /// <inheritdoc/>
@@ -163,7 +157,7 @@ namespace AggregateConfigBuildTask.Tests.Unit
         /// <summary>
         /// Converts a file search pattern (with * and ?) to a regex pattern.
         /// </summary>
-        private string ConvertPatternToRegex(string searchPattern)
+        private static string ConvertPatternToRegex(string searchPattern)
         {
             // Escape special regex characters except for * and ?
             string escapedPattern = Regex.Escape(searchPattern);

--- a/src/UnitTests/VirtualFileSystem.cs
+++ b/src/UnitTests/VirtualFileSystem.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace AggregateConfig.Tests.Unit
+namespace AggregateConfigBuildTask.Tests.Unit
 {
     internal class VirtualFileSystem : IFileSystem
     {

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AggregateConfigBuildTask" Version="$(Version)" />
+        <PackageReference Include="AggregateConfigBuildTask" Version="[$(Version)]" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.20.71" />

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -15,7 +15,6 @@
         <PackageReference Include="AggregateConfigBuildTask" Version="[$(Version)]" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Moq" Version="4.20.71" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
         <PackageReference Include="System.Text.Json" Version="8.0.4" />

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -12,10 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AggregateConfigBuildTask" Version="$(Version)">
-            <PrivateAssets>all</PrivateAssets>
-            <ExcludeAssets>native;contentFiles;analyzers;runtime</ExcludeAssets>
-        </PackageReference>
+        <PackageReference Include="AggregateConfigBuildTask" Version="$(Version)" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.20.71" />


### PR DESCRIPTION
1. Generate NuGet package with symbols and move binaries to tasks folder instead of lib so we don't need excludeassets in the packagereference.
2. Improve performance when handling a lot of files and add a basic stress test
3. Fix an exception when merging config files with multiple lists