### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ public class AppConfig
 You can now load and use the configuration data as follows:
 
 ```csharp
-var applicationConfig = LoadFromEmbeddedResource<AppConfig>("YourAssemblyName.output.json");
+var applicationConfig = LoadFromEmbeddedResource<AppConfig>("YourAssemblyName.out.output.json");
 
 bool enabled = applicationConfig.Enabled; 
 Console.WriteLine($"Enabled: {enabled}"); // Outputs "True"

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ string environment = applicationConfig.Environment;
 Console.WriteLine($"Environment: {environment}"); // Outputs "Production"
 ```
 
-**Note:** Replace `"YourAssemblyName.output.json"` with the actual resource name, which typically includes the assembly name and the output file name.
+**Note:** Replace `"YourAssemblyName.out.output.json"` with the actual resource name, which typically includes the assembly name, output folder, and the output file name.
 
 ### Finding the Correct Resource Name
 

--- a/docfx.json
+++ b/docfx.json
@@ -19,14 +19,14 @@
   "build": {
     "globalMetadata": {
       "_appTitle": "Aggregate Config Build Task",
-      "_appName": "Aggregate Config Build Task",
+      "_appName": "AggregateConfig Build Task",
       "_enableSearch": "true",
       "_appLogoPath": "image/icon/icon_50.png",
       "_appFaviconPath": "image/icon/favicon.ico",
       "_enableNewTab": "true",
       "_disableContribution": "false",
       "includePrivateMembers": "true",
-      "_appFooter": "<span>Copyright &copy; 2024 <a href=\"https://github.com/richardsondev\">Billy Richardson</a>. Generated with <a href=\"https://dotnet.github.io/docfx\">DocFX</a></span>"
+      "_appFooter": "<span>Copyright &copy; 2024 <a href=\"https://github.com/richardsondev\">Billy Richardson</a>. Generated with <a href=\"https://dotnet.github.io/docfx\">DocFX</a> with the <a href=\"https://ovasquez.github.io/docfx-material/\">Material</a> theme.</a></span>"
     },
     "resource": [
       {


### PR DESCRIPTION
when loading embedded resources at runtime, we need to include the folder path in the resource name
\+ add theme link in doc footer