### PR TITLE
Fix null message regression after quiet logger addition

### DIFF
--- a/src/Task/AggregateConfig.cs
+++ b/src/Task/AggregateConfig.cs
@@ -97,7 +97,7 @@ namespace AggregateConfigBuildTask
                 if (!Enum.TryParse(OutputType, true, out FileType outputType) ||
                     !Enum.IsDefined(typeof(FileType), outputType))
                 {
-                    logger.LogError("Invalid FileType: {0}. Available options: {1}", OutputType, string.Join(", ", Enum.GetNames(typeof(FileType))));
+                    logger.LogError(message: "Invalid FileType: {0}. Available options: {1}", OutputType, string.Join(", ", Enum.GetNames(typeof(FileType))));
                     return false;
                 }
 
@@ -105,7 +105,7 @@ namespace AggregateConfigBuildTask
                 if (!string.IsNullOrEmpty(InputType) &&
                     (!Enum.TryParse(InputType, true, out inputType) || !Enum.IsDefined(typeof(FileType), inputType)))
                 {
-                    logger.LogError("Invalid FileType: {0}. Available options: {1}", InputType, string.Join(", ", Enum.GetNames(typeof(FileType))));
+                    logger.LogError(message: "Invalid FileType: {0}. Available options: {1}", InputType, string.Join(", ", Enum.GetNames(typeof(FileType))));
                     return false;
                 }
 
@@ -121,7 +121,7 @@ namespace AggregateConfigBuildTask
 
                 if (finalResult == null)
                 {
-                    logger.LogError("No input was found! Check the input directory.");
+                    logger.LogError(message: "No input was found! Check the input directory.");
                     return false;
                 }
 
@@ -136,7 +136,7 @@ namespace AggregateConfigBuildTask
             }
             catch (Exception ex)
             {
-                logger.LogError("An unknown exception occurred: {0}", ex.Message);
+                logger.LogError(message: "An unknown exception occurred: {0}", ex.Message);
                 logger.LogErrorFromException(ex, true, true, null);
                 return false;
             }

--- a/src/Task/Logger/ITaskLogger.cs
+++ b/src/Task/Logger/ITaskLogger.cs
@@ -17,31 +17,6 @@ namespace AggregateConfigBuildTask
         void LogError(string message = null, params object[] messageArgs);
 
         /// <summary>
-        /// Logs an error message with additional parameters.
-        /// </summary>
-        /// <param name="subcategory">The subcategory of the error.</param>
-        /// <param name="errorCode">The error code.</param>
-        /// <param name="helpKeyword">The help keyword associated with the error.</param>
-        /// <param name="file">The file in which the error occurred.</param>
-        /// <param name="lineNumber">The line number where the error occurred.</param>
-        /// <param name="columnNumber">The column number where the error occurred.</param>
-        /// <param name="endLineNumber">The end line number of the error.</param>
-        /// <param name="endColumnNumber">The end column number of the error.</param>
-        /// <param name="message">The error message to log.</param>
-        /// <param name="messageArgs">Optional arguments for formatting the message.</param>
-        void LogError(
-            string subcategory = null,
-            string errorCode = null,
-            string helpKeyword = null,
-            string file = null,
-            int lineNumber = 0,
-            int columnNumber = 0,
-            int endLineNumber = 0,
-            int endColumnNumber = 0,
-            string message = null,
-            params object[] messageArgs);
-
-        /// <summary>
         /// Logs an error message from an exception.
         /// </summary>
         /// <param name="exception">The exception to log.</param>

--- a/src/Task/Logger/QuietTaskLogger.cs
+++ b/src/Task/Logger/QuietTaskLogger.cs
@@ -24,9 +24,9 @@ namespace AggregateConfigBuildTask
         }
 
         /// <inheritdoc />
-        public void LogError(string message = null, params object[] messageArgs)
+        public void LogError(string message, params object[] messageArgs)
         {
-            Log.LogError(message, messageArgs);
+            Log.LogError(message ?? "Unknown Error", messageArgs);
         }
 
         /// <inheritdoc />

--- a/src/Task/Logger/QuietTaskLogger.cs
+++ b/src/Task/Logger/QuietTaskLogger.cs
@@ -30,32 +30,6 @@ namespace AggregateConfigBuildTask
         }
 
         /// <inheritdoc />
-        public void LogError(
-            string subcategory = null,
-            string errorCode = null,
-            string helpKeyword = null,
-            string file = null,
-            int lineNumber = 0,
-            int columnNumber = 0,
-            int endLineNumber = 0,
-            int endColumnNumber = 0,
-            string message = null,
-            params object[] messageArgs)
-        {
-            Log.LogError(
-                subcategory,
-                errorCode,
-                helpKeyword,
-                file,
-                lineNumber,
-                columnNumber,
-                endLineNumber,
-                endColumnNumber,
-                message ?? "Unknown Error",
-                messageArgs);
-        }
-
-        /// <inheritdoc />
         public void LogErrorFromException(Exception exception,
             bool showStackTrace = false,
             bool showDetail = false,

--- a/src/Task/Logger/QuietTaskLogger.cs
+++ b/src/Task/Logger/QuietTaskLogger.cs
@@ -51,7 +51,7 @@ namespace AggregateConfigBuildTask
                 columnNumber,
                 endLineNumber,
                 endColumnNumber,
-                message,
+                message ?? "Unknown Error",
                 messageArgs);
         }
 

--- a/src/Task/Logger/TaskLogger.cs
+++ b/src/Task/Logger/TaskLogger.cs
@@ -22,9 +22,9 @@ namespace AggregateConfigBuildTask
         }
 
         /// <inheritdoc />
-        public void LogError(string message = null, params object[] messageArgs)
+        public void LogError(string message, params object[] messageArgs)
         {
-            Log.LogError(message, messageArgs);
+            Log.LogError(message ?? "Unknown Error", messageArgs);
         }
 
         /// <inheritdoc />

--- a/src/Task/Logger/TaskLogger.cs
+++ b/src/Task/Logger/TaskLogger.cs
@@ -49,7 +49,7 @@ namespace AggregateConfigBuildTask
                 columnNumber,
                 endLineNumber,
                 endColumnNumber,
-                message,
+                message ?? "Unknown Error",
                 messageArgs);
         }
 

--- a/src/Task/Logger/TaskLogger.cs
+++ b/src/Task/Logger/TaskLogger.cs
@@ -28,32 +28,6 @@ namespace AggregateConfigBuildTask
         }
 
         /// <inheritdoc />
-        public void LogError(
-            string subcategory = null,
-            string errorCode = null,
-            string helpKeyword = null,
-            string file = null,
-            int lineNumber = 0,
-            int columnNumber = 0,
-            int endLineNumber = 0,
-            int endColumnNumber = 0,
-            string message = null,
-            params object[] messageArgs)
-        {
-            Log.LogError(
-                subcategory,
-                errorCode,
-                helpKeyword,
-                file,
-                lineNumber,
-                columnNumber,
-                endLineNumber,
-                endColumnNumber,
-                message ?? "Unknown Error",
-                messageArgs);
-        }
-
-        /// <inheritdoc />
         public void LogErrorFromException(Exception exception,
             bool showStackTrace = false,
             bool showDetail = false,

--- a/src/Task/ObjectManager.cs
+++ b/src/Task/ObjectManager.cs
@@ -53,7 +53,7 @@ namespace AggregateConfigBuildTask
                         catch (ArgumentException ex)
                         {
                             hasError = true;
-                            log.LogError("No reader found for file {0}: {1} Stacktrace: {2}", file, ex.Message, ex.StackTrace);
+                            log.LogError(message: "No reader found for file {0}: {1} Stacktrace: {2}", file, ex.Message, ex.StackTrace);
                             continue;
                         }
 
@@ -65,7 +65,7 @@ namespace AggregateConfigBuildTask
                         catch (Exception ex)
                         {
                             hasError = true;
-                            log.LogError("Could not parse {0}: {1}", file, ex.Message);
+                            log.LogError(message: "Could not parse {0}: {1}", file, ex.Message);
                             log.LogErrorFromException(ex, true, true, file);
                             continue;
                         }


### PR DESCRIPTION
The `Microsoft.Build.Utilities.Core` LogError requires a non-null string. In the refactoring, the usages of LogError fell into a new overload of LogError which was passing a null message as the first two arguments of LogError signature were the same.

This removes the old logger and adds more protections for this case.