### PR TITLE
Remove schedules on workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ on:
       - main
   workflow_dispatch:
 
-  schedule:
-    - cron: "0 2 15-21 * 3"  # Runs at 02:00 UTC on the 3rd Wednesday of every month
-
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,9 +6,6 @@ on:
 
   workflow_dispatch:
 
-  schedule:
-    - cron: "0 2 15-21 * 3"  # Runs at 02:00 UTC on the 3rd Wednesday of every month
-
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
Remove schedule on workflows as GitHub will disable the workflows if the repo goes a few months without updates and causes the PR gates to not run.