### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/richardsondev/AggregateConfigBuildTask/security/code-scanning/2](https://github.com/richardsondev/AggregateConfigBuildTask/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are needed:

1. `contents: read` - Required for actions like `actions/checkout` to access the repository's contents.
2. `packages: read` - Required for downloading the NuGet package artifact.
3. `actions: read` - Required for downloading and uploading artifacts.

We will add the `permissions` block at the workflow level to apply these permissions to all jobs. This ensures consistency and avoids redundancy.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
