### PR TITLE
Add icon for external links in docs toc

### DIFF
--- a/toc.yml
+++ b/toc.yml
@@ -4,8 +4,8 @@ items:
   href: README.md
 - name: Code Docs
   href: docs/
-- name: GitHub
+- name: GitHub 🔗
   href: https://github.com/richardsondev/AggregateConfigBuildTask
-- name: NuGet
+- name: NuGet 🔗
   href: https://www.nuget.org/packages/AggregateConfigBuildTask
 memberLayout: memberpage


### PR DESCRIPTION
Add icon for external links in docs toc to avoid confusion that the link leaves the docs