### PR TITLE
chore: enable FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ permissions:
   packages: read
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,6 +15,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     environment:


### PR DESCRIPTION
## Summary

Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a top-level environment variable to all GitHub Actions workflow files.

## What changed

- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the workflow-level `env:` block in each `.github/workflows/*.yml` file

## Why

GitHub is migrating JavaScript-based Actions from Node.js 20 to Node.js 24. Setting this environment variable opts in to running all JavaScript-based actions on the Node.js 24 runtime, ensuring compatibility ahead of the official cutover.

No action versions were modified — they are already on modern versions that support Node.js 24.
